### PR TITLE
chore: fix 1password quick access. new binds

### DIFF
--- a/hypr/.config/hypr/modules/binds.conf
+++ b/hypr/.config/hypr/modules/binds.conf
@@ -6,15 +6,22 @@
 $terminal = kitty
 $fileManager = dolphin
 $menu = wofi --show drun
+$browser = firefox
 
 $mainMod = super # Sets "Windows" key as main modifier
 
 # See https://wiki.hyprland.org/Configuring/Binds/ for more
 
 # Program launch binds
-bind = $mainMod, Q, exec, $terminal
+bind = $mainMod, T, exec, $terminal
 bind = $mainMod, E, exec, $fileManager
 bind = $mainMod, SPACE, exec, $menu
+bind = $mainMod, B, exec, $browser
+
+bind = CTRL SHIFT, S, exec, [float; center; workspace spotify] spotify # launch spotify in special spotify workspace
+
+bind = CTRL SHIFT, SPACE, exec, [float; center] 1password # for full view floating
+# bind = CTRL + SHIFT, SPACE, exec, 1password --quick-access # for regular quick access [BROKEN :( ]
 
 # Application  manipulation
 bind = $mainMod, M, exit, # EXITS HYPERLAND

--- a/hypr/.config/hypr/modules/monitor-and-rules.conf
+++ b/hypr/.config/hypr/modules/monitor-and-rules.conf
@@ -35,3 +35,12 @@ workspace = 0, monitor:$rightVert
 
 windowrulev2 = suppressevent maximize, class:.* # You'll probably like this.
 
+windowrulev2 = float, class:(Spotify)
+windowrulev2 = center, class:(Spotify)
+windowrulev2 = workspace spotify, class:(Spotify)
+
+# Since quick access buggy, these makes regular 1password act like quick access
+windowrulev2 = float, class:(1Password)
+windowrulev2 = center, class:(1Password)
+windowrulev2 = stayfocused, class:(1Password)
+windowrulev2 = size 700 500, class:(1Password)


### PR DESCRIPTION
- Use regular 1password instead of quick access. Window rules for it
- New binds to launch terminal, browser, spotify and 1password