### PR TITLE
chore: set default monitor for cursor on startup

### DIFF
--- a/hypr/.config/hypr/modules/monitor-and-rules.conf
+++ b/hypr/.config/hypr/modules/monitor-and-rules.conf
@@ -6,6 +6,10 @@
 $main=DP-3
 $rightVert=DP-2
 
+cursor {
+    default_monitor = LG Electronics LG ULTRAGEAR 0x00005669
+}
+
 # See https://wiki.hyprland.org/Configuring/Monitors/
 #
 # Use `hyprctl monitors` to see monitor information


### PR DESCRIPTION
- Makes the cursor start on DP-3 (Main monitor) on startup rather than DP-2